### PR TITLE
Updated interfaces for plugin Wallet Contacts

### DIFF
--- a/src/main/java/com/bitdubai/fermat_api/layer/_15_middleware/wallet_contacts/DealsWithWalletContacts.java
+++ b/src/main/java/com/bitdubai/fermat_api/layer/_15_middleware/wallet_contacts/DealsWithWalletContacts.java
@@ -1,0 +1,15 @@
+package com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts;
+
+/**
+ * The Class <code>com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts.DealsWithWalletContacts</code>
+ * indicates that the plugin needs the functionality of a WalletContactsManager
+ * <p/>
+ *
+ * Created by Leon Acosta - (laion.cj91@gmail.com) on 08/06/15.
+ *
+ * @version 1.0
+ * @since Java JDK 1.7
+ */
+public interface DealsWithWalletContacts {
+    public void setWalletContactsManager (WalletContactsManager walletContactsManager);
+}

--- a/src/main/java/com/bitdubai/fermat_api/layer/_15_middleware/wallet_contacts/WalletContacsManager.java
+++ b/src/main/java/com/bitdubai/fermat_api/layer/_15_middleware/wallet_contacts/WalletContacsManager.java
@@ -1,7 +1,0 @@
-package com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts;
-
-/**
- * Created by loui on 18/02/15.
- */
-public interface WalletContacsManager {
-}

--- a/src/main/java/com/bitdubai/fermat_api/layer/_15_middleware/wallet_contacts/WalletContact.java
+++ b/src/main/java/com/bitdubai/fermat_api/layer/_15_middleware/wallet_contacts/WalletContact.java
@@ -1,0 +1,104 @@
+package com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts;
+
+import com.bitdubai.fermat_api.layer._1_definition.money.CryptoAddress;
+import com.bitdubai.fermat_api.layer._5_user.UserTypes;
+
+import java.util.UUID;
+
+/**
+ * The Class <code>com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts.WalletContact</code>
+ * indicates the functionality of a WalletContact and its attributes
+ * <p/>
+ *
+ * Created by Leon Acosta - (laion.cj91@gmail.com) on 08/06/15.
+ * @version 1.0
+ * @since Java JDK 1.7
+ */
+public interface WalletContact {
+
+
+    /**
+     * Return the contactId
+     *
+     * @return UUID
+     */
+    public UUID getContactId();
+
+    /**
+     * Set the contactId
+     *
+     * @param contactId contact's id
+     */
+    public void setContactId(UUID contactId);
+
+    /**
+     * Return the walletId
+     *
+     * @return UUID
+     */
+    public UUID getWalletId();
+
+    /**
+     * Set the walletId
+     *
+     * @param walletId wallet's id
+     */
+    public void setWalletId(UUID walletId);
+
+    /**
+     * Return the userType
+     *
+     * @return UserTypes
+     */
+    public UserTypes getUserType();
+
+    /**
+     * Set the userType
+     *
+     * @param userType user's type
+     */
+    public void setUserType(UserTypes userType);
+
+    /**
+     * Return the cryptoAddress
+     *
+     * @return CryptoAddress
+     */
+    public CryptoAddress getCryptoAddress();
+
+    /**
+     * Set the cryptoAddress
+     *
+     * @param cryptoAddress delivered cryptoAddress
+     */
+    public void setCryptoAddress(CryptoAddress cryptoAddress);
+
+    /**
+     * Return the userId
+     *
+     * @return UUID
+     */
+    public UUID getUserId();
+
+    /**
+     * Set the userId
+     *
+     * @param userId user's id
+     */
+    public void setUserId(UUID userId);
+
+
+    /**
+     * Return the userName
+     *
+     * @return String
+     */
+    public String getUserName();
+
+    /**
+     * Set the userName
+     *
+     * @param userName user's name
+     */
+    public void setUserName(String userName);
+}

--- a/src/main/java/com/bitdubai/fermat_api/layer/_15_middleware/wallet_contacts/WalletContactsManager.java
+++ b/src/main/java/com/bitdubai/fermat_api/layer/_15_middleware/wallet_contacts/WalletContactsManager.java
@@ -1,0 +1,34 @@
+package com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts;
+
+import com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts.exceptions.CantCreateWalletContactException;
+import com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts.exceptions.CantDeleteWalletContactException;
+import com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts.exceptions.CantGetAllWalletContactsException;
+import com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts.exceptions.CantUpdateWalletContactException;
+import com.bitdubai.fermat_api.layer._1_definition.money.CryptoAddress;
+import com.bitdubai.fermat_api.layer._5_user.UserTypes;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * The Class <code>com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts.WalletContactsManager</code>
+ * indicates the functionality of a WalletContactsManager
+ * <p/>
+ *
+ * Created by loui on 18/02/15.
+ * Reviewed by Leon Acosta - (laion.cj91@gmail.com) on 08/06/15.
+ * @version 1.0
+ * @since Java JDK 1.7
+ */
+public interface WalletContactsManager {
+
+    public List<WalletContact> listWalletContacts(UUID walletId) throws CantGetAllWalletContactsException;
+
+    public List<WalletContact> listWalletContactsScrolling(UUID walletId, Integer max, Integer offset) throws CantGetAllWalletContactsException;
+
+    public WalletContact createWalletContact(CryptoAddress cryptoAddress, UUID userId, String userName, UserTypes userType, UUID walletId) throws CantCreateWalletContactException;
+
+    public void updateWalletContact(WalletContact walletContact) throws CantUpdateWalletContactException;
+
+    public void deleteWalletContact(UUID contactId) throws CantDeleteWalletContactException;
+}

--- a/src/main/java/com/bitdubai/fermat_api/layer/_15_middleware/wallet_contacts/exceptions/CantCreateWalletContactException.java
+++ b/src/main/java/com/bitdubai/fermat_api/layer/_15_middleware/wallet_contacts/exceptions/CantCreateWalletContactException.java
@@ -1,0 +1,28 @@
+package com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts.exceptions;
+
+/**
+ * The Class <code>com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts.exceptions.CantCreateWalletContactException</code>
+ * is thrown when an error occurs trying to create a new contact for a wallet
+ * <p/>
+ * Created by Leon Acosta - (laion.cj91@gmail.com) on 05/06/15.
+ *
+ * @version 1.0
+ * @since Java JDK 1.7
+ */
+public class CantCreateWalletContactException extends Exception {
+
+    /**
+     * Constructor
+     */
+    public CantCreateWalletContactException(){
+        super();
+    }
+
+    /**
+     * Constructor whit parameter
+     * @param msg
+     */
+    public CantCreateWalletContactException(String msg){
+        super(msg);
+    }
+}

--- a/src/main/java/com/bitdubai/fermat_api/layer/_15_middleware/wallet_contacts/exceptions/CantDeleteWalletContactException.java
+++ b/src/main/java/com/bitdubai/fermat_api/layer/_15_middleware/wallet_contacts/exceptions/CantDeleteWalletContactException.java
@@ -1,0 +1,28 @@
+package com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts.exceptions;
+
+/**
+ * The Class <code>com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts.exceptions.CantDeleteWalletContactException</code>
+ * is thrown when an error occurs trying to delete any contact from a wallet
+ * <p/>
+ * Created by Leon Acosta - (laion.cj91@gmail.com) on 09/06/15.
+ *
+ * @version 1.0
+ * @since Java JDK 1.7
+ */
+public class CantDeleteWalletContactException extends Exception {
+
+    /**
+     * Constructor
+     */
+    public CantDeleteWalletContactException(){
+        super();
+    }
+
+    /**
+     * Constructor whit parameter
+     * @param msg
+     */
+    public CantDeleteWalletContactException(String msg){
+        super(msg);
+    }
+}

--- a/src/main/java/com/bitdubai/fermat_api/layer/_15_middleware/wallet_contacts/exceptions/CantGetAllWalletContactsException.java
+++ b/src/main/java/com/bitdubai/fermat_api/layer/_15_middleware/wallet_contacts/exceptions/CantGetAllWalletContactsException.java
@@ -1,0 +1,28 @@
+package com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts.exceptions;
+
+/**
+ * The Class <code>com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts.exceptions.CantGetAllWalletContactsException</code>
+ * is thrown when an error occurs trying to get all contacts from a wallet
+ * <p/>
+ * Created by Leon Acosta - (laion.cj91@gmail.com) on 05/06/15.
+ *
+ * @version 1.0
+ * @since Java JDK 1.7
+ */
+public class CantGetAllWalletContactsException extends Exception {
+
+    /**
+     * Constructor
+     */
+    public CantGetAllWalletContactsException(){
+        super();
+    }
+
+    /**
+     * Constructor whit parameter
+     * @param msg
+     */
+    public CantGetAllWalletContactsException(String msg){
+        super(msg);
+    }
+}

--- a/src/main/java/com/bitdubai/fermat_api/layer/_15_middleware/wallet_contacts/exceptions/CantUpdateWalletContactException.java
+++ b/src/main/java/com/bitdubai/fermat_api/layer/_15_middleware/wallet_contacts/exceptions/CantUpdateWalletContactException.java
@@ -1,0 +1,28 @@
+package com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts.exceptions;
+
+/**
+ * The Class <code>com.bitdubai.fermat_api.layer._15_middleware.wallet_contacts.exceptions.CantUpdateWalletContactException</code>
+ * is thrown when an error occurs trying to update any contact from a wallet
+ * <p/>
+ * Created by Leon Acosta - (laion.cj91@gmail.com) on 09/06/15.
+ *
+ * @version 1.0
+ * @since Java JDK 1.7
+ */
+public class CantUpdateWalletContactException extends Exception {
+
+    /**
+     * Constructor
+     */
+    public CantUpdateWalletContactException(){
+        super();
+    }
+
+    /**
+     * Constructor whit parameter
+     * @param msg
+     */
+    public CantUpdateWalletContactException(String msg){
+        super(msg);
+    }
+}


### PR DESCRIPTION
Changed interface name from WalletContacsManager to WalletContactsManager.
Added methods:
- listWalletContacts
- listWalletContactsScrolling
- createWalletContact
- updateWalletContact
- deleteWalletContact

Created new interface WalletContact.java
- The interface haves the methods needed by a Wallet Contact.

Created new interface DealsWithWalletContacts.java
-The implementation of this interface indicates that the plugin needs the functionality of a WalletContactsManager

Created Exception CantCreateWalletContactException
-This exception is thrown when an error occurs trying to create a new contact for a wallet

Created Exception CantDeleteWalletContactException
-This exception is thrown when an error occurs trying to delete any contact from a wallet

Created Exception CantUpdateWalletContactException …
-This exception is thrown when an error occurs trying to update a contact from a wallet

Created Exception CantGetAllWalletContactsException …
-The exception is thrown when an error occurs trying to get all contacts from a wallet
